### PR TITLE
Remove `inspector` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,15 +14,12 @@ rust-version = "1.67.0"
 
 [[example]]
 name = "simple"
-required-features = ["inspect"]
 
 [[example]]
 name = "multiple"
-required-features = ["inspect"]
 
 [features]
 default = ["serialize"]
-inspect = ["bevy-inspector-egui"]
 serialize = ["serde"]
 
 [dependencies]
@@ -30,8 +27,8 @@ bevy = { version = "0.11", default-features = false, features = [
     "bevy_render",
     "bevy_ui"
 ] }
-bevy-inspector-egui = { version = "0.19", optional = true }
 serde = { version = "^1", features = ["derive"], optional = true }
 
 [dev-dependencies]
 bevy = "0.11"
+bevy-inspector-egui = "0.20"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ inspect = ["bevy-inspector-egui"]
 serialize = ["serde"]
 
 [dependencies]
-bevy = { version = "0.11" }
+bevy = { version = "0.11", default-features = false, features = [
+    "bevy_render",
+    "bevy_ui"
+] }
 bevy-inspector-egui = { version = "0.19", optional = true }
 serde = { version = "^1", features = ["derive"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,6 @@ bevy = { version = "0.11", default-features = false, features = [
 ] }
 bevy-inspector-egui = { version = "0.19", optional = true }
 serde = { version = "^1", features = ["derive"], optional = true }
+
+[dev-dependencies]
+bevy = "0.11"

--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ Aviable and compatible versions
 - [Multiple Joysticks Desktop](./examples/multiple.rs)
 
 # Features
-- inspect: for world inspect with egui inspector
+
 - serialize (default): for serialization support for all types (usable for save and load settings)
 
 ```toml
 virtual_joystick = {
     version = "*",
     default-features = false,
-    features = [ "inspect", "serialize" ]
+    features = [ "serialize" ]
 }
 ```
 
@@ -60,7 +60,7 @@ Check out the [examples](./examples) for details.
 
 ```sh
 # to run example
-cargo run --example simple -F=inspect
+cargo run --example simple
 ```
 
 Add to Cargo.toml

--- a/src/behaviour.rs
+++ b/src/behaviour.rs
@@ -1,14 +1,10 @@
 use bevy::prelude::*;
 
-#[cfg(feature = "inspect")]
-use bevy_inspector_egui::prelude::*;
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 
 #[derive(Reflect, Clone, Copy, Debug, Default, PartialEq, Eq)]
-#[cfg_attr(feature = "inspect", derive(InspectorOptions))]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "inspect", reflect(InspectorOptions))]
 pub enum VirtualJoystickAxis {
     #[default]
     Both,
@@ -39,9 +35,7 @@ impl VirtualJoystickAxis {
 }
 
 #[derive(Reflect, Clone, Copy, Debug, Default, PartialEq, Eq)]
-#[cfg_attr(feature = "inspect", derive(InspectorOptions))]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "inspect", reflect(InspectorOptions))]
 pub enum VirtualJoystickType {
     /// Static position
     Fixed,

--- a/src/joystick.rs
+++ b/src/joystick.rs
@@ -9,9 +9,6 @@ use bevy::{
     },
 };
 
-#[cfg(feature = "inspect")]
-use bevy_inspector_egui::prelude::*;
-
 use crate::{VirtualJoystickAxis, VirtualJoystickType};
 
 /// The tint color of the image
@@ -20,8 +17,6 @@ use crate::{VirtualJoystickAxis, VirtualJoystickType};
 /// respecting transparent areas.
 #[derive(Component, Copy, Clone, Debug, Reflect)]
 #[reflect(Component, Default)]
-#[cfg_attr(feature = "inspect", derive(InspectorOptions))]
-#[cfg_attr(feature = "inspect", reflect(InspectorOptions))]
 pub struct TintColor(pub Color);
 
 impl TintColor {
@@ -42,8 +37,6 @@ impl From<Color> for TintColor {
 
 #[derive(Component, Copy, Clone, Debug, Default, Reflect)]
 #[reflect(Component, Default)]
-#[cfg_attr(feature = "inspect", derive(InspectorOptions))]
-#[cfg_attr(feature = "inspect", reflect(InspectorOptions))]
 pub struct VirtualJoystickInteractionArea;
 
 #[derive(Bundle, Debug, Default)]


### PR DESCRIPTION
bevy-inspector-egui now works perfectly fine through Reflect, so no need
to also derive inspector options when we don't use any of its
annotations.

depends on #10 