### PR TITLE
Improve serde feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ name = "simple"
 name = "multiple"
 
 [features]
-default = ["serialize"]
-serialize = ["serde"]
+default = ["serde"]
+serde = ["dep:serde"]
 
 [dependencies]
 bevy = { version = "0.11", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,15 +14,12 @@ rust-version = "1.67.0"
 
 [[example]]
 name = "simple"
-required-features = ["inspect"]
 
 [[example]]
 name = "multiple"
-required-features = ["inspect"]
 
 [features]
 default = ["serialize"]
-inspect = ["bevy-inspector-egui"]
 serialize = ["serde"]
 
 [dependencies]
@@ -30,8 +27,8 @@ bevy = { version = "0.11", default-features = false, features = [
     "bevy_render",
     "bevy_ui"
 ] }
-bevy-inspector-egui = { version = "0.19", optional = true }
 serde = { version = "^1", features = ["derive"], optional = true }
 
 [dev-dependencies]
 bevy = "0.11"
+bevy-inspector-egui = "0.20"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ inspect = ["bevy-inspector-egui"]
 serialize = ["serde"]
 
 [dependencies]
-bevy = { version = "0.11" }
+bevy = { version = "0.11", default-features = false, features = [
+    "bevy_render",
+    "bevy_ui"
+] }
 bevy-inspector-egui = { version = "0.19", optional = true }
 serde = { version = "^1", features = ["derive"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ bevy = { version = "0.11", default-features = false, features = [
     "bevy_render",
     "bevy_ui"
 ] }
+serde = { version = "^1", optional = true }
+
+[build-dependencies]
 serde = { version = "^1", features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,6 @@ bevy = { version = "0.11", default-features = false, features = [
 ] }
 bevy-inspector-egui = { version = "0.19", optional = true }
 serde = { version = "^1", features = ["derive"], optional = true }
+
+[dev-dependencies]
+bevy = "0.11"

--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ Aviable and compatible versions
 - [Multiple Joysticks Desktop](./examples/multiple.rs)
 
 # Features
-- inspect: for world inspect with egui inspector
+
 - serialize (default): for serialization support for all types (usable for save and load settings)
 
 ```toml
 virtual_joystick = {
     version = "*",
     default-features = false,
-    features = [ "inspect", "serialize" ]
+    features = [ "serialize" ]
 }
 ```
 
@@ -60,7 +60,7 @@ Check out the [examples](./examples) for details.
 
 ```sh
 # to run example
-cargo run --example simple -F=inspect
+cargo run --example simple
 ```
 
 Add to Cargo.toml

--- a/README.md
+++ b/README.md
@@ -45,13 +45,13 @@ Aviable and compatible versions
 
 # Features
 
-- serialize (default): for serialization support for all types (usable for save and load settings)
+- `serde` (default): for serialization support for all types through [`serde`](https://serde.rs) (useful for save and load settings)
 
 ```toml
 virtual_joystick = {
     version = "*",
     default-features = false,
-    features = [ "serialize" ]
+    features = [ "serde" ]
 }
 ```
 

--- a/src/behaviour.rs
+++ b/src/behaviour.rs
@@ -1,14 +1,10 @@
 use bevy::prelude::*;
 
-#[cfg(feature = "inspect")]
-use bevy_inspector_egui::prelude::*;
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 
 #[derive(Reflect, Clone, Copy, Debug, Default, PartialEq, Eq)]
-#[cfg_attr(feature = "inspect", derive(InspectorOptions))]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "inspect", reflect(InspectorOptions))]
 pub enum VirtualJoystickAxis {
     #[default]
     Both,
@@ -39,9 +35,7 @@ impl VirtualJoystickAxis {
 }
 
 #[derive(Reflect, Clone, Copy, Debug, Default, PartialEq, Eq)]
-#[cfg_attr(feature = "inspect", derive(InspectorOptions))]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "inspect", reflect(InspectorOptions))]
 pub enum VirtualJoystickType {
     /// Static position
     Fixed,

--- a/src/behaviour.rs
+++ b/src/behaviour.rs
@@ -1,10 +1,10 @@
 use bevy::prelude::*;
 
-#[cfg(feature = "serialize")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[derive(Reflect, Clone, Copy, Debug, Default, PartialEq, Eq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum VirtualJoystickAxis {
     #[default]
     Both,
@@ -35,7 +35,7 @@ impl VirtualJoystickAxis {
 }
 
 #[derive(Reflect, Clone, Copy, Debug, Default, PartialEq, Eq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum VirtualJoystickType {
     /// Static position
     Fixed,


### PR DESCRIPTION
- Rename from `serialize` to `serde` to follow conventions and rust API guidelines:
https://rust-lang.github.io/api-guidelines/naming.html#feature-names-are-free-of-placeholder-words-c-feature
- Move serde/derive to build-dependencies

Depends on #11 