### PR TITLE
Support both touch and mouse on same target platform (touch for Web Assembly target)

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -10,18 +10,11 @@ use crate::{
     VirtualJoystickType,
 };
 
-#[derive(Clone, Copy, Debug, Default, Reflect, PartialEq, Eq)]
-pub enum TouchOrMouse {
-    #[default]
-    Touch,
-    Mouse,
-}
-
 #[derive(Event)]
 pub enum InputEvent {
-    StartDrag { id: u64, pos: Vec2, touch_or_mouse: TouchOrMouse },
-    Dragging { id: u64, pos: Vec2, touch_or_mouse: TouchOrMouse },
-    EndDrag { id: u64, pos: Vec2, touch_or_mouse: TouchOrMouse },
+    StartDrag { id: u64, pos: Vec2, is_mouse: bool },
+    Dragging { id: u64, pos: Vec2, is_mouse: bool },
+    EndDrag { id: u64, pos: Vec2, is_mouse: bool },
 }
 
 fn is_some_and<T>(opt: Option<T>, cb: impl FnOnce(T) -> bool) -> bool {
@@ -52,9 +45,9 @@ pub fn update_input<S: VirtualJoystickID>(
         }
         for event in &input_events {
             match event {
-                InputEvent::StartDrag { id, pos, touch_or_mouse } => {
-                    if let Some(current_interaction_touch_or_mouse) = &knob.current_interaction_touch_or_mouse {
-                        if *current_interaction_touch_or_mouse != *touch_or_mouse {
+                InputEvent::StartDrag { id, pos, is_mouse } => {
+                    if let Some(current_iteraction_is_mouse) = &knob.current_iteraction_is_mouse {
+                        if *current_iteraction_is_mouse != *is_mouse {
                             continue;
                         }
                     }
@@ -66,7 +59,7 @@ pub fn update_input<S: VirtualJoystickID>(
                         knob.start_pos = *pos;
                         knob.current_pos = *pos;
                         knob.delta = Vec2::ZERO;
-                        knob.current_interaction_touch_or_mouse = Some(*touch_or_mouse);
+                        knob.current_iteraction_is_mouse = Some(*is_mouse);
                         send_values.send(VirtualJoystickEvent {
                             id: node.id.clone(),
                             event: VirtualJoystickEventType::Press,
@@ -76,9 +69,9 @@ pub fn update_input<S: VirtualJoystickID>(
                         });
                     }
                 }
-                InputEvent::Dragging { id, pos, touch_or_mouse } => {
-                    if let Some(current_interaction_touch_or_mouse) = &knob.current_interaction_touch_or_mouse {
-                        if *current_interaction_touch_or_mouse != *touch_or_mouse {
+                InputEvent::Dragging { id, pos, is_mouse } => {
+                    if let Some(current_iteraction_is_mouse) = &knob.current_iteraction_is_mouse {
+                        if *current_iteraction_is_mouse != *is_mouse {
                             continue;
                         }
                     }
@@ -102,9 +95,13 @@ pub fn update_input<S: VirtualJoystickID>(
                         d.y.signum() * d.y.abs().min(1.),
                     );
                 }
-                InputEvent::EndDrag { id, pos: _, touch_or_mouse } => {
-                    if let Some(current_interaction_touch_or_mouse) = &knob.current_interaction_touch_or_mouse {
-                        if *current_interaction_touch_or_mouse != *touch_or_mouse {
+                InputEvent::EndDrag {
+                    id,
+                    pos: _,
+                    is_mouse,
+                } => {
+                    if let Some(current_iteraction_is_mouse) = &knob.current_iteraction_is_mouse {
+                        if *current_iteraction_is_mouse != *is_mouse {
                             continue;
                         }
                     }
@@ -116,7 +113,7 @@ pub fn update_input<S: VirtualJoystickID>(
                     knob.start_pos = Vec2::ZERO;
                     knob.current_pos = Vec2::ZERO;
                     knob.delta = Vec2::ZERO;
-                    knob.current_interaction_touch_or_mouse = None;
+                    knob.current_iteraction_is_mouse = None;
                     send_values.send(VirtualJoystickEvent {
                         id: node.id.clone(),
                         event: VirtualJoystickEventType::Up,
@@ -156,15 +153,27 @@ pub fn update_joystick(
         match phase {
             // Start drag
             TouchPhase::Started => {
-                send_values.send(InputEvent::StartDrag { id: *id, pos: *pos, touch_or_mouse: TouchOrMouse::Touch });
+                send_values.send(InputEvent::StartDrag {
+                    id: *id,
+                    pos: *pos,
+                    is_mouse: false,
+                });
             }
             // Dragging
             TouchPhase::Moved => {
-                send_values.send(InputEvent::Dragging { id: *id, pos: *pos, touch_or_mouse: TouchOrMouse::Touch });
+                send_values.send(InputEvent::Dragging {
+                    id: *id,
+                    pos: *pos,
+                    is_mouse: false,
+                });
             }
             // End drag
             TouchPhase::Ended | TouchPhase::Canceled => {
-                send_values.send(InputEvent::EndDrag { id: *id, pos: *pos, touch_or_mouse: TouchOrMouse::Touch });
+                send_values.send(InputEvent::EndDrag {
+                    id: *id,
+                    pos: *pos,
+                    is_mouse: false,
+                });
             }
         }
     }
@@ -182,17 +191,29 @@ pub fn update_joystick_by_mouse(
     for mousebtn in mousebtn_evr.read() {
         // End drag
         if mousebtn.button == MouseButton::Left && mousebtn.state == ButtonState::Released {
-            send_values.send(InputEvent::EndDrag { id: 0, pos, touch_or_mouse: TouchOrMouse::Mouse });
+            send_values.send(InputEvent::EndDrag {
+                id: 0,
+                pos,
+                is_mouse: true,
+            });
         }
 
         // Start drag
         if mousebtn.button == MouseButton::Left && mousebtn.state == ButtonState::Pressed {
-            send_values.send(InputEvent::StartDrag { id: 0, pos, touch_or_mouse: TouchOrMouse::Mouse });
+            send_values.send(InputEvent::StartDrag {
+                id: 0,
+                pos,
+                is_mouse: true,
+            });
         }
     }
 
     // Dragging
     if mouse_button_input.pressed(MouseButton::Left) {
-        send_values.send(InputEvent::Dragging { id: 0, pos, touch_or_mouse: TouchOrMouse::Mouse });
+        send_values.send(InputEvent::Dragging {
+            id: 0,
+            pos,
+            is_mouse: true,
+        });
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,15 +47,10 @@ impl<S: VirtualJoystickID> Plugin for VirtualJoystickPlugin<S> {
             .register_type::<VirtualJoystickEventType>()
             .add_event::<VirtualJoystickEvent<S>>()
             .add_event::<InputEvent>()
+            .add_systems(PreUpdate, update_joystick.before(update_input::<S>))
             .add_systems(
                 PreUpdate,
-                update_joystick
-                    .before(update_input::<S>),
-            )
-            .add_systems(
-                PreUpdate,
-                update_joystick_by_mouse
-                    .before(update_input::<S>),
+                update_joystick_by_mouse.before(update_input::<S>),
             )
             .add_systems(PreUpdate, update_input::<S>)
             .add_systems(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ mod ui;
 mod utils;
 
 pub use behaviour::{VirtualJoystickAxis, VirtualJoystickType};
-use input::{run_if_pc, update_input, update_joystick, update_joystick_by_mouse, InputEvent};
+use input::{update_input, update_joystick, update_joystick_by_mouse, InputEvent};
 pub use ui::{
     VirtualJoystickBundle, VirtualJoystickInteractionArea, VirtualJoystickNode,
     VirtualJoystickUIBackground, VirtualJoystickUIKnob,
@@ -50,14 +50,12 @@ impl<S: VirtualJoystickID> Plugin for VirtualJoystickPlugin<S> {
             .add_systems(
                 PreUpdate,
                 update_joystick
-                    .before(update_input::<S>)
-                    .run_if(not(run_if_pc)),
+                    .before(update_input::<S>),
             )
             .add_systems(
                 PreUpdate,
                 update_joystick_by_mouse
-                    .before(update_input::<S>)
-                    .run_if(run_if_pc),
+                    .before(update_input::<S>),
             )
             .add_systems(PreUpdate, update_input::<S>)
             .add_systems(

--- a/src/ui/bundles.rs
+++ b/src/ui/bundles.rs
@@ -3,7 +3,7 @@ use bevy::{prelude::*, ui::RelativeCursorPosition};
 #[cfg(feature = "inspect")]
 use bevy_inspector_egui::prelude::*;
 
-use crate::{input::TouchOrMouse, VirtualJoystickAxis, VirtualJoystickID, VirtualJoystickType};
+use crate::{VirtualJoystickAxis, VirtualJoystickID, VirtualJoystickType};
 
 #[derive(Component, Clone, Debug, Default, Reflect)]
 #[reflect(Component, Default)]
@@ -70,7 +70,10 @@ pub struct VirtualJoystickData {
     pub current_pos: Vec2,
     pub delta: Vec2,
     pub interactable_zone_rect: Rect,
-    pub current_interaction_touch_or_mouse: Option<TouchOrMouse>,
+    /// None means no current interaction<br/>
+    /// Some(false) means current interaction is touch<br/>
+    /// Some(true) means current interaction is mouse
+    pub current_iteraction_is_mouse: Option<bool>,
 }
 
 impl<S: VirtualJoystickID> VirtualJoystickBundle<S> {

--- a/src/ui/bundles.rs
+++ b/src/ui/bundles.rs
@@ -3,7 +3,7 @@ use bevy::{prelude::*, ui::RelativeCursorPosition};
 #[cfg(feature = "inspect")]
 use bevy_inspector_egui::prelude::*;
 
-use crate::{VirtualJoystickAxis, VirtualJoystickID, VirtualJoystickType};
+use crate::{input::TouchOrMouse, VirtualJoystickAxis, VirtualJoystickID, VirtualJoystickType};
 
 #[derive(Component, Clone, Debug, Default, Reflect)]
 #[reflect(Component, Default)]
@@ -70,6 +70,7 @@ pub struct VirtualJoystickData {
     pub current_pos: Vec2,
     pub delta: Vec2,
     pub interactable_zone_rect: Rect,
+    pub current_interaction_touch_or_mouse: Option<TouchOrMouse>,
 }
 
 impl<S: VirtualJoystickID> VirtualJoystickBundle<S> {


### PR DESCRIPTION
Hi @SergioRibera,

This is a suggestion for allowing touch events from the mobile browser for the Web Assembly target.
On touch screen laptops, they can use either touch or mouse.

- When touch is interacting with joystick, mouse events are ignored until touch interaction stops.
- When mouse is interacting with joystick, touch events are ignored until mouse interaction stops.

This is ready for merge if you are happy with the solution.