### PR TITLE
Set channel to stable in rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.70.0"
+channel = "stable"
 profile = "default"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
atm stable is at 1.76.0, and current hardcoded version 1.70 prevents installing newer crates.   This will allow PR https://github.com/SergioRibera/virtual_joystick/pull/20 to build.