### PR TITLE
removed unwrap in update_input for mouse cursor position

### DIFF
--- a/src/systems.rs
+++ b/src/systems.rs
@@ -95,9 +95,10 @@ pub fn update_input(
                 joystick_state.just_released = true;
             } else if let Some(touch_state) = &mut joystick_state.touch_state {
                 if touch_state.is_mouse {
-                    let new_current = q_windows.single().cursor_position().unwrap();
-                    if new_current != touch_state.current {
-                        touch_state.current = new_current;
+                    if let Some(new_current) = q_windows.single().cursor_position(){
+                        if new_current != touch_state.current {
+                            touch_state.current = new_current;
+                        }
                     }
                 } else if let Some(touch) = touches.get_pressed(touch_state.id) {
                     let touch_position = touch.position();

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -95,7 +95,7 @@ pub fn update_input(
                 joystick_state.just_released = true;
             } else if let Some(touch_state) = &mut joystick_state.touch_state {
                 if touch_state.is_mouse {
-                    if let Some(new_current) = q_windows.single().cursor_position(){
+                    if let Some(new_current) = q_windows.single().cursor_position() {
                         if new_current != touch_state.current {
                             touch_state.current = new_current;
                         }


### PR DESCRIPTION
Hey,

Firstly, thank you for this package, its awesome, functional and easy to use! 

I had one thing bugging me, when I was testing joystick on my desktop using cursor, the game would panic if I accidentally put cursor outside of window. This change fixes it. 

It simply doesnt update the position of the cursor if the cursor is outside and seems to be working fine after the cursor is back in window.