### PR TITLE
fix: Fix touches randomly not resetting joystick

### DIFF
--- a/src/systems.rs
+++ b/src/systems.rs
@@ -82,7 +82,7 @@ pub fn update_input(
 
             // Continue and clear touch state if the left mouse button has just been released or the touch
             // input has just been released.
-            if (touch_state.is_mouse && mouse_buttons.just_released(MouseButton::Left))
+            if (touch_state.is_mouse && !mouse_buttons.pressed(MouseButton::Left))
                 || (!touch_state.is_mouse && touches.get_pressed(touch_state.id).is_none())
             {
                 state.touch_state = None;

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -83,7 +83,7 @@ pub fn update_input(
             // Continue and clear touch state if the left mouse button has just been released or the touch
             // input has just been released.
             if (touch_state.is_mouse && mouse_buttons.just_released(MouseButton::Left))
-                || touches.get_pressed(touch_state.id).is_none()
+                || (!touch_state.is_mouse && touches.get_pressed(touch_state.id).is_none())
             {
                 state.touch_state = None;
                 state.just_released = true;

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -80,8 +80,7 @@ pub fn update_input(
         if let Some(touch_state) = &mut state.touch_state {
             touch_state.just_pressed = false;
 
-            // Continue and clear touch state if the left mouse button has just been released or the touch
-            // input has just been released.
+            // Continue and clear touch state if left mouse button or touch is no longer pressed.
             if (touch_state.is_mouse && !mouse_buttons.pressed(MouseButton::Left))
                 || (!touch_state.is_mouse && touches.get_pressed(touch_state.id).is_none())
             {

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -83,7 +83,7 @@ pub fn update_input(
             // Continue and clear touch state if the left mouse button has just been released or the touch
             // input has just been released.
             if (touch_state.is_mouse && mouse_buttons.just_released(MouseButton::Left))
-                || touches.just_released(touch_state.id)
+                || touches.get_pressed(touch_state.id).is_none()
             {
                 state.touch_state = None;
                 state.just_released = true;


### PR DESCRIPTION
## Purpose

`VirtualJoystickState::touch_state` and `VirtualJoystickState::just_released` were only reset on `Touches::just_released(id)`.

This does not include cancelled touches and should actually be reset if touch is no longer pressed. Bevy's api is somewhat confusing regarding this because this is different for mouse inputs, but for touches this means that we have to use `Touches::get_pressed(id).is_none()` instead which checks exactly that.

## Testing

I have tested this in my own game and have also attached recordings of that. I have also tested this in the examples, but because of #49 I did not want to attach those videos here since otherwise it would be confusing.

## Bug Recordings

### Before Fix

https://github.com/user-attachments/assets/329d0247-0883-4cb3-a90b-58bce9abdb16

### After Fix

https://github.com/user-attachments/assets/db97fb3f-0322-4653-a74d-255635acaa1d