### PR TITLE
refactor: Do not use id for mouse and rename TouchState to PointerState

### DIFF
--- a/src/behavior.rs
+++ b/src/behavior.rs
@@ -11,7 +11,7 @@ use variadics_please::all_tuples;
 
 use crate::{
     VirtualJoystickUIBackground,
-    components::{TouchState, VirtualJoystickState},
+    components::{PointerState, VirtualJoystickState},
 };
 
 pub trait VirtualJoystickBehavior: Send + Sync + 'static {
@@ -121,12 +121,12 @@ impl VirtualJoystickBehavior for JoystickInvisible {
             return;
         };
         if joystick_state.just_released
-            || *joystick_visibility != Visibility::Hidden && joystick_state.touch_state.is_none()
+            || *joystick_visibility != Visibility::Hidden && joystick_state.pointer_state.is_none()
         {
             *joystick_visibility = Visibility::Hidden;
         }
-        if let Some(touch_state) = &joystick_state.touch_state {
-            if touch_state.just_pressed {
+        if let Some(pointer_state) = &joystick_state.pointer_state {
+            if pointer_state.just_pressed {
                 *joystick_visibility = Visibility::Inherited;
             }
         }
@@ -144,14 +144,14 @@ impl VirtualJoystickBehavior for JoystickFixed {
 
         joystick_state.base_offset = Vec2::ZERO;
 
-        // Return if `touch_state` is `None` and set delta to `ZERO`.
-        let Some(touch_state) = &joystick_state.touch_state else {
+        // Return if `pointer_state` is `None` and set delta to `ZERO`.
+        let Some(pointer_state) = &joystick_state.pointer_state else {
             joystick_state.delta = Vec2::ZERO;
             return;
         };
 
         // Set `joystick_state.delta`.
-        let offset = touch_state.current - joystick_base_rect.center();
+        let offset = pointer_state.current - joystick_base_rect.center();
         joystick_state.delta = joystick_delta(joystick_base_rect, offset, false);
     }
 }
@@ -168,14 +168,15 @@ impl VirtualJoystickBehavior for JoystickDynamic {
             return;
         };
 
-        // Return if `touch_state` is `None` and set delta to `ZERO`.
-        let Some(touch_state) = update_base_offset(&mut joystick_state, joystick_base_rect) else {
+        // Return if `pointer_state` is `None` and set delta to `ZERO`.
+        let Some(pointer_state) = update_base_offset(&mut joystick_state, joystick_base_rect)
+        else {
             joystick_state.delta = Vec2::ZERO;
             return;
         };
 
         // Set `joystick_state.delta`.
-        let offset = touch_state.current
+        let offset = pointer_state.current
             - (joystick_rect.min + joystick_state.base_offset + joystick_base_rect.half_size());
         joystick_state.delta = joystick_delta(joystick_base_rect, offset, false);
 
@@ -195,18 +196,19 @@ impl VirtualJoystickBehavior for JoystickFloating {
             return;
         };
 
-        // Return if `touch_state` is `None` or `touch_state.just_pressed` and set delta to `ZERO`.
-        let Some(touch_state) = update_base_offset(&mut joystick_state, joystick_base_rect) else {
+        // Return if `pointer_state` is `None` or `pointer_state.just_pressed` and set delta to `ZERO`.
+        let Some(pointer_state) = update_base_offset(&mut joystick_state, joystick_base_rect)
+        else {
             joystick_state.delta = Vec2::ZERO;
             return;
         };
-        if touch_state.just_pressed {
+        if pointer_state.just_pressed {
             joystick_state.delta = Vec2::ZERO;
             return;
         }
 
         // Set `joystick_state.delta`.
-        let offset = touch_state.current - joystick_base_rect.center();
+        let offset = pointer_state.current - joystick_base_rect.center();
         joystick_state.delta = joystick_delta(joystick_base_rect, offset, true);
     }
 }
@@ -234,20 +236,20 @@ fn joystick_base_rect(world: &World, entity: Entity) -> Option<Rect> {
 }
 
 /// Update [`VirtualJoystickState::base_offset`] and return the associated [`TouchState`] as an [`Option`].
-fn update_base_offset(state: &mut VirtualJoystickState, rect: Rect) -> Option<&TouchState> {
-    // Return None if `state.touch_state` is `None` and set `state.base_offset` to ZERO if joystick was just released.
-    let Some(touch_state) = &state.touch_state else {
+fn update_base_offset(state: &mut VirtualJoystickState, rect: Rect) -> Option<&PointerState> {
+    // Return None if `state.pointer_state` is `None` and set `state.base_offset` to ZERO if joystick was just released.
+    let Some(pointer_state) = &state.pointer_state else {
         if state.just_released {
             state.base_offset = Vec2::ZERO;
         }
         return None;
     };
 
-    // Center `state.base_offset` from starting point if joystick was just pressed and return `touch_state`.
-    if touch_state.just_pressed {
-        state.base_offset = touch_state.start - rect.center();
+    // Center `state.base_offset` from starting point if joystick was just pressed and return `pointer_state`.
+    if pointer_state.just_pressed {
+        state.base_offset = pointer_state.start - rect.center();
     }
-    Some(touch_state)
+    Some(pointer_state)
 }
 
 /// The normalized delta for [`VirtualJoystickState::delta`] calculated from an offset

--- a/src/components.rs
+++ b/src/components.rs
@@ -64,7 +64,7 @@ impl<S: VirtualJoystickID> std::fmt::Debug for VirtualJoystickNode<S> {
 #[derive(Component, Clone, Debug, Default, Reflect)]
 #[reflect(Component, Default)]
 pub struct VirtualJoystickState {
-    pub touch_state: Option<TouchState>,
+    pub pointer_state: Option<PointerState>,
     pub just_released: bool,
     pub base_offset: Vec2,
     pub delta: Vec2,
@@ -72,7 +72,7 @@ pub struct VirtualJoystickState {
 impl VirtualJoystickState {
     // Reset input related fields.
     pub fn reset_input(&mut self) {
-        self.touch_state = None;
+        self.pointer_state = None;
         self.just_released = true;
     }
 }
@@ -96,21 +96,22 @@ impl<S: VirtualJoystickID> VirtualJoystickNode<S> {
 
 #[derive(Clone, Debug, Default, Reflect)]
 #[reflect(Default)]
-pub struct TouchState {
+pub struct PointerState {
+    /// Contains [`Touch`](bevy::input::touch::Touch) id if the input is a touch or [`None`] if not.
     pub id: Option<u64>,
     pub start: Vec2,
     pub current: Vec2,
     pub just_pressed: bool,
 }
 
-impl TouchState {
+impl PointerState {
     /// Set new [`Self::current`].
     pub fn set_new_current(&mut self, new_current: Vec2) {
         if self.current != new_current {
             self.current = new_current;
         }
     }
-    /// Initialize new touch state.
+    /// Initialize new pointer state.
     pub fn new(id: Option<u64>, pos: Vec2) -> Self {
         Self {
             id,

--- a/src/components.rs
+++ b/src/components.rs
@@ -69,6 +69,13 @@ pub struct VirtualJoystickState {
     pub base_offset: Vec2,
     pub delta: Vec2,
 }
+impl VirtualJoystickState {
+    // Reset input related fields.
+    pub fn reset_input(&mut self) {
+        self.touch_state = None;
+        self.just_released = true;
+    }
+}
 
 impl<S: VirtualJoystickID> VirtualJoystickNode<S> {
     pub fn with_id(mut self, id: S) -> Self {
@@ -90,8 +97,7 @@ impl<S: VirtualJoystickID> VirtualJoystickNode<S> {
 #[derive(Clone, Debug, Default, Reflect)]
 #[reflect(Default)]
 pub struct TouchState {
-    pub id: u64,
-    pub is_mouse: bool,
+    pub id: Option<u64>,
     pub start: Vec2,
     pub current: Vec2,
     pub just_pressed: bool,
@@ -104,21 +110,10 @@ impl TouchState {
             self.current = new_current;
         }
     }
-    /// Initialize as touch state from touch position.
-    pub fn from_touch_pos(id: u64, pos: Vec2) -> Self {
+    /// Initialize new touch state.
+    pub fn new(id: Option<u64>, pos: Vec2) -> Self {
         Self {
             id,
-            is_mouse: false,
-            start: pos,
-            current: pos,
-            just_pressed: true,
-        }
-    }
-    /// Initialize as mouse state from mouse position.
-    pub fn from_mouse_pos(id: u64, pos: Vec2) -> Self {
-        Self {
-            id,
-            is_mouse: true,
             start: pos,
             current: pos,
             just_pressed: true,

--- a/src/components.rs
+++ b/src/components.rs
@@ -70,7 +70,7 @@ pub struct VirtualJoystickState {
     pub delta: Vec2,
 }
 impl VirtualJoystickState {
-    // Reset input related fields.
+    /// Reset input related fields.
     pub fn reset_input(&mut self) {
         self.pointer_state = None;
         self.just_released = true;

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -18,7 +18,7 @@ use bevy::{
 use crate::{
     VirtualJoystickID, VirtualJoystickMessage, VirtualJoystickMessageType, VirtualJoystickNode,
     components::{
-        TouchState, VirtualJoystickInteractionArea, VirtualJoystickState,
+        PointerState, VirtualJoystickInteractionArea, VirtualJoystickState,
         VirtualJoystickUIBackground, VirtualJoystickUIKnob,
     },
 };
@@ -77,36 +77,36 @@ pub fn update_input(
             node_rect(node, transform.translation, ui_scale.0)
         };
 
-        if let Some(touch_state) = &mut state.touch_state {
-            touch_state.just_pressed = false;
+        if let Some(pointer_state) = &mut state.pointer_state {
+            pointer_state.just_pressed = false;
 
             // Either reset `state` input if it has just been released or update with current position.
-            if let Some(id) = touch_state.id {
+            if let Some(id) = pointer_state.id {
                 if touches.just_released(id) {
                     state.reset_input();
                 } else if let Some(touch) = touches.get_pressed(id) {
-                    touch_state.set_new_current(touch.position());
+                    pointer_state.set_new_current(touch.position());
                 }
             } else {
                 if mouse_buttons.just_released(MouseButton::Left) {
                     state.reset_input();
                 } else if let Some(current) = window.cursor_position() {
-                    touch_state.set_new_current(current);
+                    pointer_state.set_new_current(current);
                 }
             }
         } else if let Some(touch) = touches
             .iter()
             .find(|touch| interaction_rect.contains(touch.position()))
         {
-            // If using touch and within the interaction rect, set `state.touch_state` to touch input.
-            state.touch_state = Some(TouchState::new(Some(touch.id()), touch.position()));
+            // If using touch and within the interaction rect, set `state.pointer_state` to touch input.
+            state.pointer_state = Some(PointerState::new(Some(touch.id()), touch.position()));
         } else if mouse_buttons.just_pressed(MouseButton::Left)
             && let Some(mouse_pos) = window.cursor_position()
             && interaction_rect.contains(mouse_pos)
         {
             // If the left mouse button has just been pressed within the interaction rect,
-            // set `state.touch_state` to mouse input.
-            state.touch_state = Some(TouchState::new(None, mouse_pos));
+            // set `state.pointer_state` to mouse input.
+            state.pointer_state = Some(PointerState::new(None, mouse_pos));
         }
     }
 }
@@ -173,8 +173,8 @@ pub fn update_action<S: VirtualJoystickID>(world: &mut World) {
         };
         let drag_action = if joystick_state.just_released {
             DragAction::End
-        } else if let Some(touch_state) = &joystick_state.touch_state {
-            if touch_state.just_pressed {
+        } else if let Some(pointer_state) = &joystick_state.pointer_state {
+            if pointer_state.just_pressed {
                 DragAction::Start
             } else {
                 DragAction::Move
@@ -304,11 +304,11 @@ fn message_type_and_value(
     if state.just_released {
         Some((VirtualJoystickMessageType::Up, Vec2::ZERO))
     } else {
-        state.touch_state.as_ref().map(|touch_state| {
-            if touch_state.just_pressed {
-                (VirtualJoystickMessageType::Press, touch_state.current)
+        state.pointer_state.as_ref().map(|pointer_state| {
+            if pointer_state.just_pressed {
+                (VirtualJoystickMessageType::Press, pointer_state.current)
             } else {
-                (VirtualJoystickMessageType::Drag, touch_state.current)
+                (VirtualJoystickMessageType::Drag, pointer_state.current)
             }
         })
     }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -80,40 +80,33 @@ pub fn update_input(
         if let Some(touch_state) = &mut state.touch_state {
             touch_state.just_pressed = false;
 
-            // Continue and clear touch state if the left mouse button has just been released or the touch
-            // input has just been released.
-            if (touch_state.is_mouse && mouse_buttons.just_released(MouseButton::Left))
-                || touches.just_released(touch_state.id)
-            {
-                state.touch_state = None;
-                state.just_released = true;
-                continue;
-            }
-
-            // Continue and set new current from touch input
-            if let Some(touch) = touches.get_pressed(touch_state.id) {
-                touch_state.set_new_current(touch.position());
-                continue;
-            }
-            // Set new current position from cursor position if using mouse.
-            if touch_state.is_mouse
-                && let Some(current) = window.cursor_position()
-            {
-                touch_state.set_new_current(current);
+            // Either reset `state` input if it has just been released or update with current position.
+            if let Some(id) = touch_state.id {
+                if touches.just_released(id) {
+                    state.reset_input();
+                } else if let Some(touch) = touches.get_pressed(id) {
+                    touch_state.set_new_current(touch.position());
+                }
+            } else {
+                if mouse_buttons.just_released(MouseButton::Left) {
+                    state.reset_input();
+                } else if let Some(current) = window.cursor_position() {
+                    touch_state.set_new_current(current);
+                }
             }
         } else if let Some(touch) = touches
             .iter()
             .find(|touch| interaction_rect.contains(touch.position()))
         {
             // If using touch and within the interaction rect, set `state.touch_state` to touch input.
-            state.touch_state = Some(TouchState::from_touch_pos(touch.id(), touch.position()));
+            state.touch_state = Some(TouchState::new(Some(touch.id()), touch.position()));
         } else if mouse_buttons.just_pressed(MouseButton::Left)
             && let Some(mouse_pos) = window.cursor_position()
             && interaction_rect.contains(mouse_pos)
         {
             // If the left mouse button has just been pressed within the interaction rect,
             // set `state.touch_state` to mouse input.
-            state.touch_state = Some(TouchState::from_mouse_pos(0, mouse_pos));
+            state.touch_state = Some(TouchState::new(None, mouse_pos));
         }
     }
 }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -66,17 +66,6 @@ pub fn update_input(
     for (entity, node, transform, mut state) in joystick_query {
         state.just_released = false;
 
-        // Get interaction rect or fallback to default calculated with `transform` from `joystick_query`.
-        let interaction_rect = if let Some(children) = children_query.get(entity).into_iter().next()
-            && let Some((node, interaction_transform)) = children
-                .iter()
-                .find_map(|&child| interaction_area_query.get(child).ok())
-        {
-            node_rect(node, interaction_transform.translation, ui_scale.0)
-        } else {
-            node_rect(node, transform.translation, ui_scale.0)
-        };
-
         if let Some(pointer_state) = &mut state.pointer_state {
             pointer_state.just_pressed = false;
 
@@ -94,19 +83,30 @@ pub fn update_input(
                     pointer_state.set_new_current(current);
                 }
             }
-        } else if let Some(touch) = touches
-            .iter()
-            .find(|touch| interaction_rect.contains(touch.position()))
-        {
-            // If using touch and within the interaction rect, set `state.pointer_state` to touch input.
-            state.pointer_state = Some(PointerState::new(Some(touch.id()), touch.position()));
-        } else if mouse_buttons.just_pressed(MouseButton::Left)
-            && let Some(mouse_pos) = window.cursor_position()
-            && interaction_rect.contains(mouse_pos)
-        {
-            // If the left mouse button has just been pressed within the interaction rect,
-            // set `state.pointer_state` to mouse input.
-            state.pointer_state = Some(PointerState::new(None, mouse_pos));
+        } else {
+            // Get rect or fallback to default calculated with `transform` from `joystick_query`.
+            let rect = if let Some(children) = children_query.get(entity).into_iter().next()
+                && let Some((node, interaction_transform)) = children
+                    .iter()
+                    .find_map(|&child| interaction_area_query.get(child).ok())
+            {
+                node_rect(node, interaction_transform.translation, ui_scale.0)
+            } else {
+                node_rect(node, transform.translation, ui_scale.0)
+            };
+
+            // Set `pointer_state` according to if input is in `interaction_rect`.
+            state.pointer_state =
+                if let Some(touch) = touches.iter().find(|touch| rect.contains(touch.position())) {
+                    Some(PointerState::new(Some(touch.id()), touch.position()))
+                } else if mouse_buttons.just_pressed(MouseButton::Left)
+                    && let Some(mouse_pos) = window.cursor_position()
+                    && rect.contains(mouse_pos)
+                {
+                    Some(PointerState::new(None, mouse_pos))
+                } else {
+                    None
+                };
         }
     }
 }


### PR DESCRIPTION
## Purpose

Bevy does not assign ids to mouse input, therefore storing one is unnecessary.

By inserting None for id if we are using a mouse, we can also just use that to check if input is from a mouse which seems a lot cleaner.

Additionally this avoids previously duplicated checks in one of the branches by just first processing touch and mouse in the else branch.

### Edit

I have now also renamed `TouchState` to `PointerState` since TouchState suggests that it is only four touches, but it actually is for any pointer.

Additionally and slightly out of the scope of this pr, I have also made sure that we are not calling node_rect unnecessarily which required a small refactor of the else branch in update_input.

## Testing

This has been tested on mobile with the `simple_mobile` example and on linux with the `simple` example.