### PR TITLE
fixup: Add android-game-activity feature to mobile examples

### DIFF
--- a/examples/multiple_joysticks_mobile/Cargo.toml
+++ b/examples/multiple_joysticks_mobile/Cargo.toml
@@ -8,5 +8,5 @@ name = "multiple"
 crate-type = ["lib", "cdylib"]
 
 [dependencies]
-bevy = "0.19"
+bevy = { version = "0.19", features = ["android-game-activity"] }
 virtual_joystick = { path = "../../" }

--- a/examples/simple_mobile/Cargo.toml
+++ b/examples/simple_mobile/Cargo.toml
@@ -8,5 +8,5 @@ name = "simple"
 crate-type = ["lib", "cdylib"]
 
 [dependencies]
-bevy = "0.19"
+bevy = { version = "0.19", features = ["android-game-activity"] }
 virtual_joystick = { path = "../../" }


### PR DESCRIPTION
This is now required to be added explicitly in bevy 0.19.

Further details: https://bevy.org/learn/migration-guides/0-18-to-0-19/#remove-android-game-activity-from-default